### PR TITLE
Removed OpenData.city

### DIFF
--- a/The-Basics-of-Open-Data/Data-Repositories.md
+++ b/The-Basics-of-Open-Data/Data-Repositories.md
@@ -26,7 +26,6 @@ An at-a-glance list of available data repositories.
 | JKAN              | open source   |              |
 | Junar             | hosted        |              |
 | NuData            | hosted        |              |
-| OpenData.city     | free & hosted | CKAN-powered |
 | OpenDataSoft      | hosted        |              |
 | Open Data Catalog | open source   |              |
 | Socrata           | hosted        |              |


### PR DESCRIPTION
Seems to have shut down. Website no longer works, and last redirected to http://www.civicdashboards.com/, which is run by OpenGov.